### PR TITLE
Patches `User` in request if no `className`

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,9 @@ function updateRequestFunctionParams(req, res, next) {
 // Middleware to inflate a Parse.User if provided, and promote the master key option to the request
 function inflateParseUser(req, res, next) {
   if (req.body.user) {
+    if (req.body.user.className === undefined) {
+      req.body.user.className = "_User";
+    }
     req.user = Parse.Object.fromJSON(req.body.user);
   }
   req.master = req.body.master;


### PR DESCRIPTION
Before inflating Parse User we need to patch request data with a `className` property in case this isn't set. It's required in order to parse JSON properly.