### PR TITLE
Upgrade parse dependency to 1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express": "~4.9",
     "body-parser": "~1.12",
     "request": "~2.61",
-    "parse": "~1.6"
+    "parse": "~1.7"
   },
   "author": "Fosco Marotto <thedude@fb.com>",
   "license": "MIT",


### PR DESCRIPTION
I upgraded the parse module to 1.7 and I depend on some of the changes in that release. However, since parse-cloud-express still depends on an older version of the module, it installs a second version of parse and breaks code that relies on 1.7.