### PR TITLE
Use global Parse if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ See our example project
 */
 var express = require('express');
 var bodyParser = require('body-parser');
-var Parse = require('parse/node').Parse;
+var Parse = global.Parse || require('parse/node').Parse;
 var Request = require('request');
 
 var Routes = {


### PR DESCRIPTION
That helps because the parse/node module is loaded from the parse-cloud-express dependency. This way we keep a single global Parse object.